### PR TITLE
use stats::rWishart() in rwish.R for R >= 3.0.2

### DIFF
--- a/R/rwish.R
+++ b/R/rwish.R
@@ -23,12 +23,22 @@
 #' 
 #' 
 #' @export rwish
-rwish <-
-function(S0,nu=dim(S0)[1]+1)
-{
-  # sample from a Wishart distribution 
-  # with expected value nu*S0 
-  sS0<-chol(S0)
-  Z<-matrix(rnorm(nu*dim(S0)[1]),nu,dim(S0)[1])%*%sS0
-  t(Z)%*%Z
+if(R.version$major>=3 & R.version$minor>=0.2){
+	rwish <-
+	function(S0,nu=dim(S0)[1]+1)
+	{
+	  # sample from a Wishart distribution 
+	  # with expected value nu*S0 
+		rWishart(1,nu,S0)[,,1]		    
+	}
+}else{
+	rwish <-
+	function(S0,nu=dim(S0)[1]+1)
+	{
+	  # sample from a Wishart distribution 
+	  # with expected value nu*S0 		
+		sS0<-chol(S0)
+	  Z<-matrix(rnorm(nu*dim(S0)[1]),nu,dim(S0)[1])%*%sS0
+	  t(Z)%*%Z		    
+	}
 }

--- a/R/rwish.R
+++ b/R/rwish.R
@@ -27,18 +27,18 @@ if(R.version$major>=3 & R.version$minor>=0.2){
 	rwish <-
 	function(S0,nu=dim(S0)[1]+1)
 	{
-	  # sample from a Wishart distribution 
-	  # with expected value nu*S0 
+		# sample from a Wishart distribution 
+		# with expected value nu*S0 
 		rWishart(1,nu,S0)[,,1]		    
 	}
 }else{
 	rwish <-
 	function(S0,nu=dim(S0)[1]+1)
 	{
-	  # sample from a Wishart distribution 
-	  # with expected value nu*S0 		
+		# sample from a Wishart distribution 
+		# with expected value nu*S0 		
 		sS0<-chol(S0)
-	  Z<-matrix(rnorm(nu*dim(S0)[1]),nu,dim(S0)[1])%*%sS0
-	  t(Z)%*%Z		    
+		Z<-matrix(rnorm(nu*dim(S0)[1]),nu,dim(S0)[1])%*%sS0
+		t(Z)%*%Z		    
 	}
 }


### PR DESCRIPTION
Using rWishart() provides a small performance gain for newer versions. Conditioning on the R version at the time of function creation rather than inside the function avoids checking the version on each function call.
